### PR TITLE
Use colormap for plotting lines

### DIFF
--- a/src/openbus_light/plot/line.py
+++ b/src/openbus_light/plot/line.py
@@ -100,7 +100,7 @@ def plot_lines_in_swiss_coordinates(
                 x=[center_lookup[a][0] + offset for a in _direction.station_sequence],
                 y=[center_lookup[a][1] + offset for a in _direction.station_sequence],
                 mode="lines",
-                line={"color": ColorMap[_line.name] if cmap is not None else "blue", "width": 2},  # type: ignore
+                line={"color": cmap[_line.name] if cmap is not None else "blue", "width": 2},
                 name=f"Line {_line.number} {_direction.name}<br> At {_line.permitted_frequencies}",
                 text=[
                     f"{a} to {b}, Line {_line.number} {_direction.name}" for a, b in _direction.station_names_as_pairs


### PR DESCRIPTION
## Summary
- colour bus lines using passed in colormap

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=src pytest -q`
- `PYTHONPATH=src python3 - <<'EOF'
from test_openbus_light.test_line_planning import _create_non_walking_scenario
from openbus_light.plot.line import plot_lines_in_swiss_coordinates
from openbus_light.plot._cmap import create_colormap
scenario = _create_non_walking_scenario()
cmap = create_colormap([line.name for line in scenario.bus_lines])
fig = plot_lines_in_swiss_coordinates(scenario.stations, scenario.bus_lines, cmap=cmap)
print('Traces:', len(fig.data))
fig.write_html('test_plot.html')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_685927fc016483229d6c6405a67db6ac