### PR TITLE
Fix create_colormap default color support

### DIFF
--- a/src/openbus_light/plot/_cmap.py
+++ b/src/openbus_light/plot/_cmap.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from collections.abc import Collection
-from typing import Generic, Hashable, TypeVar
+from typing import Generic, Hashable, TypeVar, cast
 
 import matplotlib.colors as mcolors
 import matplotlib.pyplot as plt
@@ -23,18 +23,20 @@ def create_colormap(elements: Collection[T], default_color: str | None = None) -
 
     >>> create_colormap(['a', 'b', 'c'])
     {'a': '#63cb5f', 'b': '#65cb5e', 'c': '#69cd5b'}
-    >>> create_colormap(['a', 'b', 'c'], default_color='red')
-    {'a': '#63cb5f', 'b': '#65cb5e', 'c': '#69cd5b'}
+    >>> cmap = create_colormap(['a', 'b', 'c'], default_color='red')
+    >>> cmap['d']
+    'red'
 
     """
     count = len(elements)
     colors = sample_colorscale(px.colors.cyclical.Phase, samplepoints=[i / count for i in range(0, count)])
-    if default_color is not None:
+
+    if default_color is None:
         return ColorMap[T]({element: colors[i] for i, element in enumerate(elements)})
 
-    cmap = defaultdict(lambda: default_color)  # type: ignore
+    cmap: defaultdict[T, str] = defaultdict(lambda: cast(str, default_color))
     cmap.update({element: colors[i] for i, element in enumerate(elements)})
-    return ColorMap[T](cmap)
+    return cast(ColorMap[T], cmap)
 
 
 def create_continuous_colormap(

--- a/test_openbus_light/test_cmap.py
+++ b/test_openbus_light/test_cmap.py
@@ -1,0 +1,23 @@
+import unittest
+from collections import defaultdict
+
+from openbus_light.plot._cmap import create_colormap
+
+
+class CreateColormapTestCase(unittest.TestCase):
+    def test_dict_returned_without_default(self) -> None:
+        cmap = create_colormap(["a", "b"])
+        self.assertIsInstance(cmap, dict)
+        self.assertNotIsInstance(cmap, defaultdict)
+        with self.assertRaises(KeyError):
+            _ = cmap["missing"]
+
+    def test_defaultdict_returned_with_default_color(self) -> None:
+        cmap = create_colormap(["a", "b"], default_color="red")
+        self.assertIsInstance(cmap, defaultdict)
+        self.assertEqual(cmap["missing"], "red")
+        self.assertNotEqual(cmap["a"], "red")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- return a defaultdict when a default color is supplied so missing keys use that color
- return a regular dict when no default color is given
- test this behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685927f6ed208322bf17029eba211395