### PR TITLE
Fix Haversine distance computation

### DIFF
--- a/src/openbus_light/manipulate/point.py
+++ b/src/openbus_light/manipulate/point.py
@@ -18,7 +18,7 @@ def calculate_distance_in_m(point_1: PointIn2D, point_2: PointIn2D) -> float:
     d_lon = radians(point_2.long) - radians(point_1.long)  # lon2 - lon1
     d_lat = radians(point_2.lat) - radians(point_1.lat)  # lat2 - lat1
 
-    value_a = sin(d_lat / 2) ** 2 + cos(point_1.lat) * cos(point_2.lat) * sin(d_lon / 2) ** 2
+    value_a = sin(d_lat / 2) ** 2 + cos(radians(point_1.lat)) * cos(radians(point_2.lat)) * sin(d_lon / 2) ** 2
     value_c = 2 * atan2(sqrt(value_a), sqrt(1 - value_a))
 
     return R * value_c


### PR DESCRIPTION
## Summary
- use latitude in radians when computing Haversine distance

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68592a2edf1083228b4283b71183a95e