### PR TITLE
Fix unittest failures

### DIFF
--- a/src/openbus_light/plan/network.py
+++ b/src/openbus_light/plan/network.py
@@ -62,7 +62,9 @@ class LPNNodeType(BaseNodeType):
 
 @dataclass(frozen=True, slots=True)
 class LPNNode(NodeABC[LPNNodeType]):
-    id: NodeName
+    """Node representation used in the line planning network."""
+
+    node_id: NodeName
     coordinates: ThreeDCoordinates
     node_type: LPNNodeType = LPNNodeType.GENERIC
     line_nr: None | LineNr = None

--- a/test_openbus_light/__init__.py
+++ b/test_openbus_light/__init__.py
@@ -1,0 +1,16 @@
+
+"""Test package configuration.
+
+Ensures that the local ``src`` directory is on ``sys.path`` so that the tests
+import the in-repository version of :mod:`openbus_light` rather than a
+potentially installed package from elsewhere.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+SRC_PATH = Path(__file__).resolve().parents[1] / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))


### PR DESCRIPTION
## Summary
- ensure tests use local src when importing `openbus_light`
- fix `LPNNode` dataclass so edges reference proper node ids

## Testing
- `python -m unittest`

------
https://chatgpt.com/codex/tasks/task_e_68594bfdf53083229f5c2816b1445a1e