### PR TITLE
Improve scenario validation tests

### DIFF
--- a/src/openbus_light/manipulate/scenario.py
+++ b/src/openbus_light/manipulate/scenario.py
@@ -45,4 +45,6 @@ def load_scenario(parameters: LinePlanningParameters, paths: ScenarioPaths) -> P
     served_stations = _drop_stations_that_are_not_served(all_stations_in_data, equalised_lines)
     demand_matrix = load_demand_matrix(served_stations, parameters, paths)
     walkable_links = find_all_walkable_distances(served_stations, parameters)
-    return PlanningScenario(demand_matrix, equalised_lines, walkable_links, served_stations)
+    scenario = PlanningScenario(demand_matrix, equalised_lines, walkable_links, served_stations)
+    scenario.check_consistency()
+    return scenario

--- a/src/openbus_light/model/scenario.py
+++ b/src/openbus_light/model/scenario.py
@@ -34,6 +34,11 @@ class PlanningScenario(NamedTuple):
         :param all_served_station_names: frozenset[str], names of all stations that are served by bus lines
         """
         all_station_names = frozenset(station.name for station in self.stations)
+        if not all_station_names.issuperset(all_served_station_names):
+            unknown_stations = all_served_station_names.difference(all_station_names)
+            raise ValueError(
+                f"Some bus lines stop at stations that are not defined in the scenario: {unknown_stations}"
+            )
         if not all_served_station_names.issuperset(all_station_names):
             not_served_stations = all_station_names.difference(all_served_station_names)
             raise ValueError(f"Some Stations are not served by any line: {not_served_stations}")
@@ -44,9 +49,13 @@ class PlanningScenario(NamedTuple):
             are not within the stations served by lines, raise error.
         :param all_served_station_names: frozenset[str], names of all stations that are served by bus lines
         """
+        all_station_names = frozenset(station.name for station in self.stations)
         all_stations_in_demand = set(
             chain.from_iterable(flows_to.keys() for flows_to in self.demand_matrix.matrix.values())
         ) | set(self.demand_matrix.all_origins())
+        if not all_station_names.issuperset(all_stations_in_demand):
+            unknown_stations = all_stations_in_demand.difference(all_station_names)
+            raise ValueError(f"Some Origins or Destinations are not defined in the scenario: {unknown_stations}")
         if not all_served_station_names.issuperset(all_stations_in_demand):
             not_served_stations = all_stations_in_demand.difference(all_served_station_names)
             raise ValueError(f"Some Origins or Destinations are not served by any line: {not_served_stations}")
@@ -57,9 +66,13 @@ class PlanningScenario(NamedTuple):
             ``walkable_distances`` are not within the stations served by lines, raise error.
         :param all_served_station_names: frozenset[str], names of all stations that are served by bus lines
         """
+        all_station_names = frozenset(station.name for station in self.stations)
         walkable_stations = set(
-            chain.from_iterable((link.ending_at.name, link.ending_at.name) for link in self.walkable_distances)
+            chain.from_iterable((link.starting_at.name, link.ending_at.name) for link in self.walkable_distances)
         )
+        if not all_station_names.issuperset(walkable_stations):
+            unknown_stations = walkable_stations.difference(all_station_names)
+            raise ValueError(f"Some Walking Distances involve stations not defined in the scenario: {unknown_stations}")
         if not all_served_station_names.issuperset(walkable_stations):
             not_served_stations = walkable_stations.difference(all_served_station_names)
             raise ValueError(f"Some Walking Distances are not served by any line: {not_served_stations}")

--- a/test_openbus_light/test_scenario.py
+++ b/test_openbus_light/test_scenario.py
@@ -4,7 +4,9 @@ from datetime import timedelta
 
 from test_openbus_light.shared import cached_scenario
 
-from openbus_light.model import PlanningScenario, PointIn2D, Station, StationName, WalkableDistance
+from unittest.mock import patch
+
+from openbus_light.model import PlanningScenario, PointIn2D, Station, StationName, WalkableDistance, Direction
 
 
 class MyTestCase(unittest.TestCase):
@@ -55,6 +57,52 @@ class MyTestCase(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             scenario_with_only_one_line.check_consistency()
+
+    def test_line_with_unknown_station_fails(self) -> None:
+        """Bus lines referencing stations not defined in the scenario should fail."""
+        line = self._baseline_scenario.bus_lines[0]
+        new_station = StationName("UNKNOWN$$")
+        new_direction = Direction(
+            line.direction_up.name,
+            line.direction_up.station_sequence + (new_station,),
+            line.direction_up.trip_times + (timedelta(seconds=60),),
+            line.direction_up.recorded_trips,
+        )
+        modified_line = line._replace(direction_up=new_direction)
+        invalid_scenario = self._baseline_scenario._replace(
+            bus_lines=(modified_line,) + self._baseline_scenario.bus_lines[1:]
+        )
+        with self.assertRaises(ValueError):
+            invalid_scenario.check_consistency()
+
+    def test_nonexistent_origin_demand_fails(self) -> None:
+        """Demand matrix containing unknown origins should fail."""
+        invalid_scenario = copy(self._baseline_scenario)
+        invalid_scenario.demand_matrix.matrix[StationName("ORIGIN$$")] = {invalid_scenario.stations[0].name: 42.0}
+        with self.assertRaises(ValueError):
+            invalid_scenario.check_consistency()
+
+    def test_walk_distance_with_unknown_start_fails(self) -> None:
+        """Walkable distances using undefined stations should fail."""
+        valid_station = self._baseline_scenario.stations[0]
+        dummy_station = Station(StationName("X"), (PointIn2D(0, 0),), tuple(), [], [])
+        walk = WalkableDistance(dummy_station, valid_station, timedelta(seconds=0))
+        invalid_scenario = self._baseline_scenario._replace(walkable_distances=(walk,))
+        with self.assertRaises(ValueError):
+            invalid_scenario.check_consistency()
+
+    def test_load_scenario_invokes_check(self) -> None:
+        """Ensure ``load_scenario`` calls ``PlanningScenario.check_consistency``."""
+        from exercise_3 import get_paths
+        from openbus_light.manipulate.scenario import load_scenario
+        from test_openbus_light.shared import test_parameters
+
+        with patch(
+            "openbus_light.model.scenario.PlanningScenario.check_consistency", side_effect=RuntimeError
+        ) as mocked:
+            with self.assertRaises(RuntimeError):
+                load_scenario(test_parameters(), get_paths())
+            mocked.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- ensure bus stops, demand and walking links reference known stations
- validate scenarios when loading via `load_scenario`
- test that `load_scenario` runs consistency checks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859525b751883229d3e6ee1d84849cb