### PR TITLE
Add docs and module docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,94 +2,19 @@
 
 [![PyPI version](https://badge.fury.io/py/openbus-light.svg)](https://badge.fury.io/py/openbus-light)
 [![Downloads](https://pepy.tech/badge/openbus-light)](https://pepy.tech/project/openbus-light)
-![black](https://img.shields.io/badge/code%20style-black-000000.svg)
-![isort](https://img.shields.io/badge/%20imports-isort-%231674b1.svg)
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
-![mypyc](https://img.shields.io/badge/mypy%20checked-100%25-brightgreen)
-![flake8](https://img.shields.io/badge/flake8%20checked-100%25-brightgreen)
-![pylint](https://img.shields.io/badge/pylint%20checked-100%25-brightgreen)
 
-This repository contains exercises developed by the **Institute for Transport Planning and Systems (IVT) at ETH Zurich**. These exercises focus on **public transport optimization**, covering topics like line planning, timetable evaluation, and operational performance analysis.
+This repository accompanies the public transport lectures at **ETH Zurich**. It provides small exercises built on top of the `openbus_light` package and demonstrates typical optimisation and analysis tasks.
 
-## Setup:
+## Project Structure
 
-You can now install `openbus_light` directly from PyPI:
+- `src/openbus_light/` – library code used by the exercises
+- `exercise_3.py` and `exercise_4.py` – starter scripts for the assignments
+- `data/` – input data used in the exercises
+- `results/` – output folder created when running the experiments
 
-```bash
-pip install openbus-light
-```
+## Getting Started
 
-If you wish to use the OR-Tools solver backend, install `ortools` as well:
+Detailed setup instructions can be found in [docs/setup.md](docs/setup.md). Once your environment is ready, follow the workflow described in [docs/usage.md](docs/usage.md).
 
-```bash
-pip install ortools
-```
-
-Alternatively, if you prefer using the provided wheel file:
-
-1. Clone the repository to a suitable location on your computer.
-2. Create your virtual environment (venv) using Python 3.10 with the command:
-   ```bash
-   python -m venv venv
-   ```
-3. Activate your venv:
-   - On Windows:
-     ```bash
-     .\venv\Scripts\activate
-     ```
-   - On macOS/Linux:
-     ```bash
-     source venv/bin/activate
-     ```
-4. Install `openbus_light` using the provided wheel file:
-   ```bash
-   pip install openbus_light-X.X.X-py3-none-any.whl
-   ```
-   (Replace `X.X.X` with the actual version number.)
-5. Verify the setup by running the unittests:
-   ```bash
-   python -m unittest
-   ```
-6. Open your preferred IDE and begin working on `exercise_3.py` and `exercise_4.py`.
-
-## Running the Line Planning Problem Experiments (Exercise 3)
-
-The line planning problem (LPP) experiments are designed to explore the impacts of various parameters on the planning outcomes. `exercise_3.py` serves as the main script for executing these experiments in parallel.
-
-### How to Run Experiments
-
-1. Ensure both `exercise_3.py` and `solve_exercise_3.py` are present in your working directory.
-2. Execute the `solve_exercise_3.py` script from your terminal to initiate the experiments:
-   ```bash
-   python solve_exercise_3.py
-   ```
-   This script will automatically run multiple configurations of the LPP in parallel, collect results, and generate insightful plots for analysis.
-3. Experiment summaries and plots will be saved in the `results` directory. Review these materials to analyze the performance and outcomes of different configurations.
-
-## Analyzing Trip and Dwell Times (Exercise 4)
-
-In `exercise_4.py`, you will analyze the trip and dwell times for bus lines using recorded measurements. This involves calculating and comparing planned versus observed trip times and dwell times for selected bus lines.
-
-### How to Run Analysis
-
-1. Ensure you've completed the setup steps and have access to the necessary data files.
-2. Run `exercise_4.py`, optionally specifying the bus line numbers for analysis. This script will load bus lines with recorded measurements, calculate trip and dwell times, and prepare the data for further analysis.
-
-**Note:** The script includes a `NotImplementedError` as a placeholder for where you will need to process and display the analysis results. This is an intentional aspect of the exercise, designed to encourage you to apply what you've learned from Exercise 3, such as plotting techniques, and extend it with additional insights, like plotting data on maps or between stations.
-
-## Adding Result Plotting
-
-Result plotting provides a visual analysis of the experiment outcomes, enhancing understanding through visual means.
-
-- After executing `solve_exercise_3.py`, visit the `results` directory to find the generated HTML files.
-- Open these files in a web browser to view the scatter and bar plots, which visualize the experiments' results. The scatter plot displays the number of vehicles versus the objective (CHF per hour), while the bar plot details the objective by activity, offering a breakdown of cost components.
-
-## Student Engagement and Adaptation
-
-Exercise 4 is purposefully left incomplete to challenge you to apply and adapt the learnings from Exercise 3. This includes utilizing plotting capabilities and integrating geographic data visualization to enrich your analysis. You are encouraged to manipulate and extend the provided code to explore creative and insightful ways of representing and analyzing the data.
-
-## Conclusion
-
-These exercises are crafted to provide a comprehensive, hands-on experience with public transport optimization, covering everything from setup and execution of line planning problems to in-depth data analysis and visualization. By following the above instructions and engaging actively with the exercises, you will deepen your understanding of transport planning challenges and solutions.
-
-This project is part of the **Institute for Transport Planning and Systems (IVT) at ETH Zurich** and is used in educational settings for students to gain hands-on experience in public transport optimization.
+Both documents target students of the Bachelor programme in Civil Engineering and should provide everything you need to reproduce the results on your own machine.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,38 @@
+# Environment Setup
+
+This project requires **Python 3.10** or newer. We recommend using a virtual environment so that Python packages used for the exercises do not interfere with other projects.
+
+## Creating a Virtual Environment
+
+1. Install Python (version 3.10 or newer).
+2. Create and activate a virtual environment:
+   ```bash
+   python -m venv venv
+   source venv/bin/activate  # On Windows use: .\venv\Scripts\activate
+   ```
+
+## Installing Dependencies
+
+All required Python packages are listed in `requirements.txt`. Install them with
+
+```bash
+pip install -r requirements.txt
+```
+
+Alternatively you can install the published package directly from PyPI:
+
+```bash
+pip install openbus-light
+```
+
+To use the optional OR-Tools solver backend run
+
+```bash
+pip install ortools
+```
+
+Afterwards run the tests to ensure that your environment is ready:
+
+```bash
+pytest
+```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,33 @@
+# Usage Guide
+
+This repository contains two main exercises that demonstrate how to use the `openbus_light` toolkit.
+
+## Working with `exercise_3.py`
+
+`exercise_3.py` explores the line planning problem. The typical workflow is:
+
+1. Ensure the dataset in `data/` is available.
+2. Run the helper script which executes several configurations in parallel:
+   ```bash
+   python solve_exercise_3.py
+   ```
+   The results, including HTML plots, are written to the `results/` directory.
+3. Inspect the generated plots in your web browser to analyse the impact of different parameters.
+
+You can also run a single experiment manually:
+```bash
+python exercise_3.py --help
+```
+This shows the available command line options such as the planning horizon, solver settings and output paths.
+
+## Working with `exercise_4.py`
+
+`exercise_4.py` analyses recorded trip and dwell times for individual lines. The typical steps are:
+
+1. Make sure you have completed the environment setup from `docs/setup.md`.
+2. Execute the script and optionally select the bus lines to analyse:
+   ```bash
+   python exercise_4.py --lines 1 2 3
+   ```
+   Without any arguments the script processes all available lines with recorded measurements.
+3. The script will compute the statistics and, once you complete the TODO sections, produce visualisations similar to those in Exercise 3.

--- a/src/openbus_light/plot/__init__.py
+++ b/src/openbus_light/plot/__init__.py
@@ -1,6 +1,16 @@
+"""Convenience imports for the plotting helpers used in the exercises.
+
+The functions exposed here allow you to visualise demand matrices, bus lines and
+line-planning networks. They are primarily used in ``exercise_3.py`` and
+``exercise_4.py`` to analyse the provided scenario for the city of Winterthur.
+"""
+
 from ._background import PlotBackground
 from ._cmap import ColorMap, create_colormap
 from .demand import create_od_plot, create_station_and_demand_plot
 from .line import create_station_and_line_plot, plot_lines_in_swiss_coordinates
 from .line_usage import plot_usage_for_each_direction
-from .network import plot_network_in_swiss_coordinate_grid, plot_network_usage_in_swiss_coordinates
+from .network import (
+    plot_network_in_swiss_coordinate_grid,
+    plot_network_usage_in_swiss_coordinates,
+)

--- a/src/openbus_light/plot/_background.py
+++ b/src/openbus_light/plot/_background.py
@@ -1,6 +1,10 @@
+"""Simple container for background map information."""
+
 from typing import NamedTuple
 
 
 class PlotBackground(NamedTuple):
+    """Location of the background image and its coordinates."""
+
     path_to_image: str
     bounding_box: tuple[float, float, float, float]

--- a/src/openbus_light/plot/_cmap.py
+++ b/src/openbus_light/plot/_cmap.py
@@ -1,3 +1,5 @@
+"""Colour map utilities for the visualisations."""
+
 from collections import defaultdict
 from collections.abc import Collection
 from typing import Generic, Hashable, TypeVar, cast

--- a/src/openbus_light/plot/_convert.py
+++ b/src/openbus_light/plot/_convert.py
@@ -1,3 +1,5 @@
+"""Coordinate conversion helpers used by the plotting routines."""
+
 import math
 
 from numba import njit

--- a/src/openbus_light/plot/demand.py
+++ b/src/openbus_light/plot/demand.py
@@ -1,3 +1,5 @@
+"""Functions for visualising demand and station locations."""
+
 from __future__ import annotations
 
 from itertools import chain

--- a/src/openbus_light/plot/line.py
+++ b/src/openbus_light/plot/line.py
@@ -1,3 +1,5 @@
+"""Plotting helpers for bus lines and their stations."""
+
 from collections.abc import Collection
 from itertools import chain
 

--- a/src/openbus_light/plot/line_usage.py
+++ b/src/openbus_light/plot/line_usage.py
@@ -1,3 +1,5 @@
+"""Visualisations of passenger load along each line."""
+
 from typing import Mapping, NamedTuple, Sequence
 
 import numpy as np

--- a/src/openbus_light/plot/network.py
+++ b/src/openbus_light/plot/network.py
@@ -1,3 +1,5 @@
+"""Plotting routines for the line planning network."""
+
 from collections import defaultdict
 from itertools import chain
 from typing import NamedTuple


### PR DESCRIPTION
## Summary
- document environment setup and exercise usage under `docs/`
- shorten `README` and link to new docs
- add module level docstrings in plotting package

## Testing
- `pytest -q` *(fails: TypeError: non-default argument 'node_id' follows default argument)*

------
https://chatgpt.com/codex/tasks/task_e_68595a73766083228032b507a4bf2716