### PR TITLE
Fix dataclass field order in network module

### DIFF
--- a/src/openbus_light/plan/network.py
+++ b/src/openbus_light/plan/network.py
@@ -64,7 +64,7 @@ class LPNNodeType(BaseNodeType):
 class LPNNode(NodeABC[LPNNodeType]):
     """Node representation used in the line planning network."""
 
-    node_id: NodeName
+    id: NodeName
     coordinates: ThreeDCoordinates
     node_type: LPNNodeType = LPNNodeType.GENERIC
     line_nr: None | LineNr = None


### PR DESCRIPTION
## Summary
- fix dataclass definition in `LPNNode` to avoid TypeError during test collection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68595c9a36608322b439a8a9dbdc87a4