### PR TITLE
Remove redundant forwarding methods

### DIFF
--- a/src/openbus_light/plan/network.py
+++ b/src/openbus_light/plan/network.py
@@ -81,41 +81,20 @@ class NodesForOneDirection(NamedTuple):
 class LinePlanningNetwork(MutableNetworkABC[LPNNode, LPNLink, LPNNodeType, Activity]):
     __slots__ = ()
 
-    def __init__(self, graph: igraph.Graph) -> None:
-        MutableNetworkABC.__init__(self, graph)
-
     def __eq__(self, other: object) -> bool:
         raise NotImplementedError("Equality comparison is not implemented for LinePlanningNetwork")
 
     def __repr__(self) -> str:
         return f"LinePlanningNetwork(graph=(n:{self.n_count}l:{self.l_count}))"
 
-    def __post_init__(self) -> None:
-        """
-        Check whether the graph is directed. If not, raise an error.
-        :return: None
-        """
-        if not self.graph.is_directed():
-            raise RuntimeError(f"graph of {self} must be directed")
 
     def shallow_copy(self) -> LinePlanningNetwork:
         """
         Create a shallow copy of LinePlanningNetwork.
         :return: LinePlanningNetwork, a copy of the instance
         """
-        return LinePlanningNetwork(self.graph.copy())
+        return self.copy()
 
-    @property
-    def graph(self) -> igraph.Graph:
-        return self.underlying_digraph
-
-    @property
-    def all_links(self) -> list[LPNLink]:
-        return super().all_links
-
-    @property
-    def all_nodes(self) -> list[LPNNode]:
-        return super().all_nodes
 
     @property
     def all_node_names(self) -> tuple[NodeName, ...]:
@@ -125,14 +104,14 @@ class LinePlanningNetwork(MutableNetworkABC[LPNNode, LPNLink, LPNNodeType, Activ
         """
         return tuple(self.node_ids)
 
-    def get_link_index(self, source: str, target: str) -> int:
+    def get_link_index(self, source: NodeId, target: NodeId) -> LinkIndex:
         """
         Get the index of an edge between two vertices.
-        :param source: str, the ID or name of the start vertex
-        :param target: str, the ID or name of the end vertex
-        :return: int, index of the link
+        :param source: NodeId, the ID or name of the start vertex
+        :param target: NodeId, the ID or name of the end vertex
+        :return: LinkIndex, index of the link
         """
-        return int(self.link_index_by_source_target(source, target))
+        return self.link_index_by_source_target(source, target)
 
     @classmethod
     def create_from_scenario(cls, scenario: PlanningScenario, period_duration: timedelta) -> LinePlanningNetwork:
@@ -200,21 +179,26 @@ class LinePlanningNetwork(MutableNetworkABC[LPNNode, LPNLink, LPNNodeType, Activ
             average_waiting_time: timedelta = period_duration / frequency * 0.5
             access_link = LPNLink(Activity.ACCESS_LINE, average_waiting_time, line.number, frequency)
             links_to_add.extend(
-                ((access.id, service.id), access_link) for access, service in zip(access_nodes, service_nodes)
+                ((access.node_id, service.node_id), access_link)
+                for access, service in zip(access_nodes, service_nodes)
             )
             links_to_add.extend(
-                ((transfer.id, service.id), access_link) for transfer, service in zip(transfer_nodes, service_nodes)
+                ((transfer.node_id, service.node_id), access_link)
+                for transfer, service in zip(transfer_nodes, service_nodes)
             )
         egress_link = LPNLink(Activity.EGRESS_LINE, timedelta(seconds=60), line.number, None)
         links_to_add.extend(
-            ((service.id, egress.id), egress_link) for service, egress in zip(service_nodes, egress_nodes)
+            ((service.node_id, egress.node_id), egress_link)
+            for service, egress in zip(service_nodes, egress_nodes)
         )
         links_to_add.extend(
-            ((service.id, transfer.id), egress_link) for service, transfer in zip(service_nodes, transfer_nodes)
+            ((service.node_id, transfer.node_id), egress_link)
+            for service, transfer in zip(service_nodes, transfer_nodes)
         )
         service_links = (LPNLink(Activity.IN_VEHICLE, dt, line.number, None) for dt in direction.trip_times)
         links_to_add.extend(
-            ((first.id, second.id), link) for (first, second), link in zip(pairwise(service_nodes), service_links)
+            ((first.node_id, second.node_id), link)
+            for (first, second), link in zip(pairwise(service_nodes), service_links)
         )
         return frozenset(access_nodes + egress_nodes + service_nodes + transfer_nodes), tuple(links_to_add)  # noqa
 

--- a/src/openbus_light/plan/problem.py
+++ b/src/openbus_light/plan/problem.py
@@ -381,7 +381,7 @@ def _add_flow_conservation_constraints(model: pl.LpProblem, variables: _LPPVaria
     :param data: LPPData, data of the LP problem
     """
     lpp_network = data.network
-    lpp_graph = data.network.graph
+    lpp_graph = data.network.underlying_digraph
     node_incidences = [
         (lpp_graph.incident(i, mode="in"), lpp_graph.incident(i, mode="out")) for i in lpp_graph.vs.indices
     ]

--- a/src/openbus_light/plot/network.py
+++ b/src/openbus_light/plot/network.py
@@ -65,7 +65,7 @@ def plot_network_in_swiss_coordinate_grid(
     )
 
     by_name: dict[str, _Data] = defaultdict(lambda: _Data([], [], [], []))
-    for (s, t), link in zip((es.tuple for es in network.graph.es), network.all_links):
+    for (s, t), link in network.iter_links_with_tuples():
         link: LPNLink  # type: ignore
         name = link.activity.name if link.line_nr is None else f"L:{link.line_nr}"
         start_point, end_point = projected_coordinates[s], projected_coordinates[t]
@@ -152,7 +152,9 @@ def plot_network_usage_in_swiss_coordinates(
     reduced = network.shallow_copy()
     del network
     active_lines = {line.number for line in solution.active_lines}
-    reduced.graph.delete_edges([i for i, link in enumerate(reduced.all_links) if link.line_nr not in active_lines])
+    reduced.underlying_digraph.delete_edges([
+        i for i, link in enumerate(reduced.all_links) if link.line_nr not in active_lines
+    ])
 
     all_passenger_per_link: tuple[PassengersPerLink, ...] = tuple(
         chain.from_iterable(ppl for group in solution.passengers_per_link.values() for ppl in group.values())
@@ -173,7 +175,7 @@ def plot_network_usage_in_swiss_coordinates(
     figure = go.Figure()
     projected_coordinates = _project_and_shift_network_nodes(reduced)
     already_seen_names = set()
-    for (s, t), link in zip((es.tuple for es in reduced.graph.es), reduced.all_links):
+    for (s, t), link in reduced.iter_links_with_tuples():
         link: LPNLink  # type: ignore
         use_a_straight_line = link.activity == Activity.IN_VEHICLE
         start_name, end_name = node_names[s], node_names[t]


### PR DESCRIPTION
## Summary
- use `node_id` field on `LPNNode` again
- remove unneeded init hooks and forwarders from `LinePlanningNetwork`
- rely on ugraph's copy method for shallow copies
- adopt `NodeId`/`LinkIndex` in `get_link_index`
- drop `.graph` property and update remaining uses
- use `iter_links_with_tuples` in plotting

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685957ca37e88322b0e1d822e204706b