### PR TITLE
Improve student documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,6 @@ This repository accompanies the public transport lectures at **ETH Zurich**. It 
 ## Getting Started
 
 Detailed setup instructions can be found in [docs/setup.md](docs/setup.md). Once your environment is ready, follow the workflow described in [docs/usage.md](docs/usage.md).
+More detailed explanations for each exercise are available in [docs/exercise_3.md](docs/exercise_3.md) and [docs/exercise_4.md](docs/exercise_4.md).
 
 Both documents target students of the Bachelor programme in Civil Engineering and should provide everything you need to reproduce the results on your own machine.

--- a/docs/exercise_3.md
+++ b/docs/exercise_3.md
@@ -1,0 +1,34 @@
+# Exercise 3: Line Planning
+
+This exercise introduces the line planning problem using the `openbus_light` toolkit. You will learn how to run optimisation scenarios and inspect the results.
+
+## Objective
+
+Run the provided scripts to explore how different frequencies and capacities affect the bus network. You do not need to modify the optimisation algorithms themselves, but you are encouraged to experiment with the parameters.
+
+## Step-by-Step Guide
+
+1. Complete the setup in [setup.md](setup.md).
+2. Ensure the `data/` folder is present (it is part of this repository).
+3. Open a terminal and navigate to the project root. Activate your virtual environment if you created one.
+4. Execute the helper script:
+   ```bash
+   python solve_exercise_3.py
+   ```
+   This runs several scenarios and writes the results to `results/`.
+5. After the command finishes, open the generated HTML files from the `results/` directory in your web browser. They contain interactive plots of the network usage.
+6. To try your own settings, either edit `solve_exercise_3.py` or run `exercise_3.py` directly. Use
+   ```bash
+   python exercise_3.py --help
+   ```
+   to see all available options, such as planning horizon or solver choice.
+
+## What to Look For
+
+Compare the resulting plots for different parameter sets. Observe how vehicle allocation changes and how demand is served. Consider questions like:
+
+- Which settings reduce the number of vehicles required?
+- How does increasing the permitted frequency affect passenger wait times?
+
+Write down your observations—they will help you discuss the results in the tutorial.
+

--- a/docs/exercise_4.md
+++ b/docs/exercise_4.md
@@ -1,0 +1,30 @@
+# Exercise 4: Recorded Trip Analysis
+
+In this task you analyse recorded trip and dwell times for the Winterthur bus network. The provided script already loads the data and computes basic statistics.
+
+## Objective
+
+Fill in the missing plotting code and inspect the resulting distributions of observed trip and dwell times.
+
+## Step-by-Step Guide
+
+1. Complete the installation steps from [setup.md](setup.md) if you have not done so already.
+2. Verify that `data/scenario/Messungen.zip` exists in this repository. It contains the measurement data used for this exercise.
+3. Run the script once to generate the intermediate files:
+   ```bash
+   python exercise_4.py
+   ```
+   By default all lines with available measurements are processed. Use `--lines` to restrict the analysis to specific line numbers.
+4. Open `exercise_4.py` in your editor and locate the TODO comments. Implement the sections that create violin plots for trip times and dwell times. You can take inspiration from the plotting code in `exercise_3.py`.
+5. Execute the script again. HTML files will be written under `results/Analysis/`. Open them with a web browser to view the interactive plots.
+
+## Troubleshooting Tips
+
+- If you are unsure what a variable contains, add a `print()` statement and run the script again.
+- Read error messages carefully—they usually tell you the line number where something went wrong.
+- Use short iteration cycles: modify the code a little, run the script, check the output.
+
+## Expected Result
+
+Once the TODO sections are complete you will obtain violin plots that show the distribution of observed travel and dwell times for each line direction. Use these plots to discuss possible sources of delay and variability.
+

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,10 +1,11 @@
 # Usage Guide
 
 This repository contains two main exercises that demonstrate how to use the `openbus_light` toolkit.
+Each exercise has its own README-style document with detailed instructions.
 
 ## Working with `exercise_3.py`
 
-`exercise_3.py` explores the line planning problem. The typical workflow is:
+`exercise_3.py` explores the line planning problem. A step-by-step walkthrough is available in [exercise_3.md](exercise_3.md). In short you usually:
 
 1. Ensure the dataset in `data/` is available.
 2. Run the helper script which executes several configurations in parallel:
@@ -12,22 +13,22 @@ This repository contains two main exercises that demonstrate how to use the `ope
    python solve_exercise_3.py
    ```
    The results, including HTML plots, are written to the `results/` directory.
-3. Inspect the generated plots in your web browser to analyse the impact of different parameters.
+3. Inspect the generated plots in your web browser and experiment with different parameters.
 
 You can also run a single experiment manually:
 ```bash
 python exercise_3.py --help
 ```
-This shows the available command line options such as the planning horizon, solver settings and output paths.
+This command lists all available options such as the planning horizon, solver settings and output paths.
 
 ## Working with `exercise_4.py`
 
-`exercise_4.py` analyses recorded trip and dwell times for individual lines. The typical steps are:
+`exercise_4.py` analyses recorded trip and dwell times for individual lines. A detailed walkthrough can be found in [exercise_4.md](exercise_4.md). The basic procedure is:
 
-1. Make sure you have completed the environment setup from `docs/setup.md`.
+1. Make sure you have completed the environment setup from `setup.md`.
 2. Execute the script and optionally select the bus lines to analyse:
    ```bash
    python exercise_4.py --lines 1 2 3
    ```
    Without any arguments the script processes all available lines with recorded measurements.
-3. The script will compute the statistics and, once you complete the TODO sections, produce visualisations similar to those in Exercise 3.
+3. Once you fill in the TODO sections the script will produce HTML visualisations similar to those in Exercise 3.


### PR DESCRIPTION
## Summary
- add separate guides for exercise 3 and exercise 4
- link these guides from the main README and usage instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68596b63530c8322a21f9bf94e9ecaf0